### PR TITLE
Fix bug where failed tests show as not run

### DIFF
--- a/JsTestAdapter/TestAdapter/TestRunner.cs
+++ b/JsTestAdapter/TestAdapter/TestRunner.cs
@@ -223,7 +223,7 @@ namespace JsTestAdapter.TestAdapter
                 foreach (var extraFailure in result.Failures.Skip(1))
                 {
                     testResult.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory,
-                        string.Join(Environment.NewLine, extraFailure.message, string.Join(Environment.NewLine, extraFailure.stack ?? new List<string>())
+                        string.Join(Environment.NewLine, extraFailure.message, string.Join(Environment.NewLine, extraFailure.stack ?? new List<string>()))
                     ));
                 }
                 if (result.Log != null && result.Log.Any())

--- a/JsTestAdapter/TestAdapter/TestRunner.cs
+++ b/JsTestAdapter/TestAdapter/TestRunner.cs
@@ -219,11 +219,11 @@ namespace JsTestAdapter.TestAdapter
             {
                 var failure = result.Failures.First();
                 testResult.ErrorMessage = failure.message;
-                testResult.ErrorStackTrace = string.Join(Environment.NewLine, failure.stack);
+                testResult.ErrorStackTrace = string.Join(Environment.NewLine, failure.stack ?? new List<string>());
                 foreach (var extraFailure in result.Failures.Skip(1))
                 {
                     testResult.Messages.Add(new TestResultMessage(TestResultMessage.AdditionalInfoCategory,
-                        string.Join(Environment.NewLine, extraFailure.message, string.Join(Environment.NewLine, extraFailure.stack))
+                        string.Join(Environment.NewLine, extraFailure.message, string.Join(Environment.NewLine, extraFailure.stack ?? new List<string>())
                     ));
                 }
                 if (result.Log != null && result.Log.Any())


### PR DESCRIPTION
This changes comes from https://github.com/MortenHoustonLudvigsen/JsTestAdapter/issues/2 (ref https://github.com/mstephano/JsTestAdapter/commit/304fe8b8a6f7a18dff35946af5810a64f2cb7de1). When a test fails, don't report it as Not Run, and continue to run other tests
